### PR TITLE
Refactor realtime flow to Supabase and redesign UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+*.log

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.21.2",
-    "ws": "^8.18.1"
+    "express": "^4.21.2"
   },
   "engines": {
     "node": "14.x"

--- a/public/console.html
+++ b/public/console.html
@@ -1,402 +1,1169 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Teacher Console (Multiple Questions)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Collaborative MCQ Workspace – Facilitator</title>
     <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
     />
     <style>
+      :root {
+        color-scheme: light;
+        --brand: #4b74ff;
+        --brand-accent: #2f4fdb;
+        --bg: #f3f5fd;
+        --panel: rgba(255, 255, 255, 0.85);
+        --panel-solid: #ffffff;
+        --text: #1f2436;
+        --muted: #6f7c99;
+        --muted-strong: #525b74;
+        --success: #1c9c6d;
+        --warning: #f2a100;
+        --danger: #cc3a51;
+        --border-radius: 20px;
+        --shadow: 0 18px 38px rgba(31, 36, 54, 0.12);
+        --shadow-soft: 0 10px 20px rgba(31, 36, 54, 0.08);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        background: linear-gradient(135deg, #f0f0f0 0%, #d1d1f5 100%);
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at 10% -10%, rgba(75, 116, 255, 0.18), transparent 50%),
+          radial-gradient(circle at 80% 0%, rgba(28, 156, 109, 0.12), transparent 45%),
+          var(--bg);
         min-height: 100vh;
+        padding: 32px 24px 48px;
+        color: var(--text);
       }
-      .card {
-        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        border-radius: 8px;
+
+      .app-shell {
+        max-width: 1400px;
+        margin: 0 auto;
+        display: grid;
+        gap: 28px;
       }
-      .option-subcard {
-        background: #fafafa;
-        border-radius: 6px;
-        border: 1px solid #ececec;
-        padding: 8px;
-        margin-bottom: 8px;
+
+      header {
+        border-radius: var(--border-radius);
+        padding: 28px 32px;
+        background: var(--panel);
+        backdrop-filter: blur(18px);
+        box-shadow: var(--shadow);
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 20px;
       }
-      .navbar-brand {
-        font-weight: bold;
-        font-size: 1.6rem;
+
+      .brand-title {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
       }
-      .hero-section {
-        background: #fff;
-        padding: 1rem;
-        border-radius: 8px;
-        margin-bottom: 1rem;
-        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+
+      .brand-title h1 {
+        margin: 0;
+        font-size: 2rem;
+        font-weight: 700;
       }
-      .fade-in {
-        animation: fadein 0.5s;
+
+      .brand-title p {
+        margin: 0;
+        color: var(--muted);
+        max-width: 540px;
       }
-      @keyframes fadein {
-        from { opacity:0; }
-        to { opacity:1; }
+
+      .session-meta {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        flex-wrap: wrap;
+      }
+
+      .session-code {
+        background: linear-gradient(135deg, rgba(75, 116, 255, 0.16) 0%, rgba(75, 116, 255, 0.04) 100%);
+        border-radius: 16px;
+        padding: 16px 22px;
+        display: flex;
+        flex-direction: column;
+        min-width: 200px;
+      }
+
+      .session-code span {
+        color: var(--muted);
+        font-size: 0.9rem;
+        letter-spacing: 0.08em;
+      }
+
+      .session-code strong {
+        font-size: 1.9rem;
+        letter-spacing: 0.18em;
+        margin-top: 6px;
+      }
+
+      .stage-indicator {
+        border-radius: 999px;
+        padding: 10px 20px;
+        background: rgba(28, 156, 109, 0.12);
+        color: var(--success);
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        gap: 24px;
+      }
+
+      .panel {
+        background: var(--panel-solid);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow-soft);
+        padding: 28px;
+        min-height: 280px;
+      }
+
+      .panel h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .panel .subtitle {
+        margin-top: 6px;
+        margin-bottom: 24px;
+        color: var(--muted);
+      }
+
+      .panel-session {
+        grid-column: span 4;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+
+      .panel-controls {
+        grid-column: span 8;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+
+      .panel-results {
+        grid-column: span 12;
+      }
+
+      @media (max-width: 1100px) {
+        .panel-session,
+        .panel-controls {
+          grid-column: span 12;
+        }
+      }
+
+      label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 10px;
+      }
+
+      input[type="text"],
+      textarea,
+      select {
+        width: 100%;
+        border: 1px solid rgba(31, 36, 54, 0.12);
+        border-radius: 14px;
+        padding: 12px 16px;
+        font-size: 1rem;
+        font-family: inherit;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      textarea {
+        min-height: 110px;
+        resize: vertical;
+      }
+
+      input:focus,
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: rgba(75, 116, 255, 0.45);
+        box-shadow: 0 0 0 4px rgba(75, 116, 255, 0.15);
+      }
+
+      button {
+        border: none;
+        border-radius: 14px;
+        padding: 13px 20px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        font-family: inherit;
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        transition: transform 0.1s ease, box-shadow 0.2s ease, background 0.2s ease;
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+        transform: none;
+        box-shadow: none;
+      }
+
+      .btn-primary {
+        background: linear-gradient(135deg, var(--brand) 0%, var(--brand-accent) 100%);
+        color: #fff;
+        box-shadow: 0 12px 24px rgba(75, 116, 255, 0.24);
+      }
+
+      .btn-secondary {
+        background: rgba(31, 36, 54, 0.06);
+        color: var(--muted-strong);
+      }
+
+      .btn-danger {
+        background: rgba(204, 58, 81, 0.12);
+        color: var(--danger);
+      }
+
+      .btn-primary:hover:not(:disabled) {
+        transform: translateY(-1px);
+      }
+
+      .mode-selector {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .mode-button {
+        border: 1px solid rgba(31, 36, 54, 0.12);
+        background: #f9faff;
+        border-radius: 12px;
+        padding: 14px 18px;
+        cursor: pointer;
+        flex: 1 1 180px;
+        text-align: left;
+        transition: border 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .mode-button.active {
+        border-color: rgba(75, 116, 255, 0.6);
+        background: rgba(75, 116, 255, 0.08);
+        box-shadow: 0 10px 18px rgba(75, 116, 255, 0.18);
+      }
+
+      .mode-button strong {
+        display: block;
+        font-size: 1.1rem;
+      }
+
+      .mode-button span {
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      .range-input {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .range-input input[type="range"] {
+        flex: 1;
+        accent-color: var(--brand);
+      }
+
+      .range-value {
+        background: rgba(75, 116, 255, 0.12);
+        color: var(--brand-accent);
+        padding: 6px 14px;
+        border-radius: 999px;
+        font-weight: 600;
+      }
+
+      .share-card {
+        border: 1px dashed rgba(31, 36, 54, 0.18);
+        border-radius: 16px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .share-card a {
+        color: var(--brand-accent);
+        word-break: break-word;
+        text-decoration: none;
+      }
+
+      .list {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .list-item {
+        border-radius: 12px;
+        padding: 12px 14px;
+        background: rgba(31, 36, 54, 0.04);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .results-grid {
+        display: grid;
+        gap: 18px;
+      }
+
+      @media (min-width: 900px) {
+        .results-grid {
+          grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+      }
+
+      .result-card {
+        border-radius: 18px;
+        background: rgba(75, 116, 255, 0.06);
+        padding: 18px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .progress-track {
+        width: 100%;
+        height: 8px;
+        border-radius: 999px;
+        background: rgba(31, 36, 54, 0.1);
+        overflow: hidden;
+      }
+
+      .progress-bar {
+        height: 100%;
+        border-radius: 999px;
+        background: linear-gradient(135deg, var(--brand) 0%, var(--brand-accent) 100%);
+        transition: width 0.4s ease;
+      }
+
+      .pill {
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(31, 36, 54, 0.08);
+        font-size: 0.9rem;
+      }
+
+      .explanation-block {
+        border-radius: 14px;
+        padding: 16px;
+        background: rgba(31, 36, 54, 0.04);
+      }
+
+      .timeline {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 12px;
+      }
+
+      .timeline li {
+        border-radius: 14px;
+        background: rgba(31, 36, 54, 0.05);
+        padding: 12px 16px;
+      }
+
+      .flex-between {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 32px;
+        right: 32px;
+        background: rgba(31, 36, 54, 0.92);
+        color: #fff;
+        padding: 16px 22px;
+        border-radius: 14px;
+        box-shadow: 0 16px 32px rgba(31, 36, 54, 0.22);
+        opacity: 0;
+        transform: translateY(20px);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+        pointer-events: none;
+      }
+
+      .toast.show {
+        opacity: 1;
+        transform: translateY(0);
       }
     </style>
   </head>
-  <body class="p-3">
-    <div class="container fade-in">
-      <nav class="navbar navbar-light bg-light rounded mb-4">
-        <span class="navbar-brand mb-0 h1">Teacher Console</span>
-        <span id="sessionCode" class="text-primary"></span>
-      </nav>
-
-      <div class="hero-section">
-        <h2>Welcome!</h2>
-        <p class="mb-0">
-          A unique session is created automatically. Share this link or QR with 
-          your students.
-        </p>
-      </div>
-
-      <div class="row mb-4">
-        <div class="col-md-6 mb-3">
-          <h5>Student Join Link</h5>
-          <a id="studentLink" href="#" target="_blank"></a>
-          <div id="qrcode" class="mt-2"></div>
+  <body>
+    <div class="app-shell">
+      <header>
+        <div class="brand-title">
+          <h1>Collaborative MCQ Workspace</h1>
+          <p>
+            Craft single-response, multi-response, or multi-tier experiences. Guide learners through selection, grouping, and explanation – all in real time.
+          </p>
         </div>
-        <div class="col-md-6">
-          <h5>Students Joined</h5>
-          <ul id="studentList" class="list-group"></ul>
+        <div class="session-meta">
+          <div class="session-code">
+            <span>SESSION CODE</span>
+            <strong id="sessionCode"></strong>
+          </div>
+          <div class="stage-indicator">
+            <small>Stage</small>
+            <span id="stageChip">Lobby</span>
+          </div>
         </div>
-      </div>
+      </header>
 
-      <!-- Question input + Start/Next button -->
-      <div class="card mb-3">
-        <div class="card-body">
-          <h4 class="card-title">Question Setup</h4>
-          <div class="form-group">
-            <label for="questionText">Question (Optional):</label>
-            <input
-              type="text"
-              id="questionText"
-              class="form-control"
-              placeholder="(Optional)"
-            />
-          </div>
-          <label>Number of Options:</label>
-          <div class="form-check form-check-inline">
-            <input
-              class="form-check-input"
-              type="radio"
-              name="numOptions"
-              value="2"
-              id="opt2"
-              checked
-            />
-            <label class="form-check-label" for="opt2">2</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input
-              class="form-check-input"
-              type="radio"
-              name="numOptions"
-              value="3"
-              id="opt3"
-            />
-            <label class="form-check-label" for="opt3">3</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input
-              class="form-check-input"
-              type="radio"
-              name="numOptions"
-              value="4"
-              id="opt4"
-            />
-            <label class="form-check-label" for="opt4">4</label>
+      <div class="layout">
+        <section class="panel panel-session">
+          <h2>Invite Learners</h2>
+          <p class="subtitle">Share the link or QR code so participants can join instantly.</p>
+          <div class="share-card">
+            <strong>Participant Link</strong>
+            <a id="participantLink" href="#" target="_blank" rel="noopener"></a>
+            <div class="flex-between">
+              <div>
+                <span class="muted">QR Code</span>
+              </div>
+              <div id="qrCode" style="width:140px;height:140px;"></div>
+            </div>
           </div>
 
-          <button id="startOrNextBtn" class="btn btn-success btn-block mt-3">
-            Start MCQ
-          </button>
-        </div>
+          <div>
+            <h3 style="margin-bottom:12px;">Participants</h3>
+            <div id="participantList" class="list"></div>
+            <p id="participantEmpty" class="muted" style="margin-top:12px;">Waiting for learners to join.</p>
+          </div>
+
+          <div>
+            <h3 style="margin-bottom:12px;">Completed Questions</h3>
+            <ul id="historyList" class="timeline"></ul>
+            <p id="historyEmpty" class="muted">No questions completed yet.</p>
+          </div>
+        </section>
+
+        <section class="panel panel-controls">
+          <h2>Design the Experience</h2>
+          <p class="subtitle">Choose the interaction style and launch when ready.</p>
+
+          <div>
+            <label>Question prompt</label>
+            <textarea id="questionInput" placeholder="What would you like learners to think about?" maxlength="280"></textarea>
+          </div>
+
+          <div>
+            <label>Interaction type</label>
+            <div class="mode-selector">
+              <button class="mode-button active" data-mode="single">
+                <strong>Single Response</strong>
+                <span>Each learner selects one option.</span>
+              </button>
+              <button class="mode-button" data-mode="multi">
+                <strong>Multi-Response</strong>
+                <span>Allow multiple options per learner.</span>
+              </button>
+              <button class="mode-button" data-mode="multi-tier">
+                <strong>Multi-tier Journey</strong>
+                <span>Choose → Group → Explain for deeper reasoning.</span>
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label for="optionRange">Number of options</label>
+            <div class="range-input">
+              <input id="optionRange" type="range" min="2" max="7" value="4" />
+              <span id="optionValue" class="range-value">4 options</span>
+            </div>
+          </div>
+
+          <div class="flex-between" style="margin-top:8px;">
+            <div>
+              <p class="muted" id="stageStatus">Ready to launch your first question.</p>
+            </div>
+            <div style="display:flex;gap:12px;flex-wrap:wrap;">
+              <button id="launchButton" class="btn-primary" type="button">Launch Question</button>
+              <button id="advanceButton" class="btn-secondary hidden" type="button">Advance Stage</button>
+              <button id="endSessionButton" class="btn-danger" type="button">End Session</button>
+            </div>
+          </div>
+
+          <div class="flex-between" style="margin-top:18px;">
+            <div>
+              <strong>Data & Export</strong>
+              <p class="muted" style="margin:4px 0 0;">Download a CSV snapshot of every learner response.</p>
+            </div>
+            <button id="downloadButton" class="btn-secondary" type="button" disabled>Download CSV</button>
+          </div>
+        </section>
+
+        <section class="panel panel-results">
+          <div class="flex-between">
+            <h2>Live Insights</h2>
+            <div id="responseChip" class="pill"></div>
+          </div>
+          <p class="subtitle">Monitor engagement in real time, see groupings, and capture explanations.</p>
+
+          <div id="resultsPlaceholder" class="muted" style="margin-top:24px;">Launch a question to start collecting responses.</div>
+          <div id="resultsGrid" class="results-grid"></div>
+          <div id="explanationsContainer" style="margin-top:28px;"></div>
+        </section>
       </div>
-
-      <!-- Next Explanation -->
-      <button id="nextExplanationBtn" class="btn btn-info btn-block mb-3">
-        Next (Explanation)
-      </button>
-
-      <!-- Results area -->
-      <div class="card mb-3">
-        <div class="card-body">
-          <h4 class="card-title">Results</h4>
-          <div id="resultsContainer" class="row"></div>
-        </div>
-      </div>
-
-      <!-- Stop Quiz & Download CSV -->
-      <button
-        id="stopQuizBtn"
-        class="btn btn-danger btn-block mb-2"
-      >
-        Stop Quiz
-      </button>
-
-      <button
-        id="downloadCsvBtn"
-        class="btn btn-primary btn-block"
-        style="display: none;"
-      >
-        Download CSV
-      </button>
     </div>
 
-    <!-- QRCode library -->
+    <div id="toast" class="toast" role="status"></div>
+
+    <script src="/env.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
-    <script>
-      let socket;
-      let currentSessionCode = null;
-      let currentStage = "WAITING"; // WAITING | MCQ | EXPLANATION | STOPPED
-      let isFirstQuestion = true;
+    <script type="module">
+      import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-      // Refs
-      const sessionCodeSpan = document.getElementById("sessionCode");
-      const studentLink = document.getElementById("studentLink");
-      const studentList = document.getElementById("studentList");
-      const questionText = document.getElementById("questionText");
-      const startOrNextBtn = document.getElementById("startOrNextBtn");
-      const nextExplanationBtn = document.getElementById("nextExplanationBtn");
-      const resultsContainer = document.getElementById("resultsContainer");
-      const stopQuizBtn = document.getElementById("stopQuizBtn");
-      const downloadCsvBtn = document.getElementById("downloadCsvBtn");
-
-      function connectWebSocket() {
-        socket = new WebSocket(
-          window.location.origin.replace(/^http/, "ws")
-        );
-
-        socket.addEventListener("open", () => {
-          console.log("Teacher console connected via WebSocket");
-          socket.send(JSON.stringify({ type: "TEACHER_CREATE_SESSION" }));
-        });
-
-        socket.addEventListener("message", (evt) => {
-          const data = JSON.parse(evt.data);
-          switch (data.type) {
-            case "SESSION_CREATED":
-              handleSessionCreated(data.payload.sessionCode);
-              break;
-            case "TEACHER_VIEW_UPDATE":
-              updateTeacherView(data.payload);
-              break;
-            case "CSV_DATA":
-              triggerDownload(data.payload.csv, data.payload.filename);
-              break;
-            case "QUIZ_STOPPED":
-              alert("Quiz has been stopped.");
-              currentStage = "STOPPED";
-              disableAllControls();
-              downloadCsvBtn.style.display = "block";
-              break;
-            case "ERROR":
-              alert(data.payload.message);
-              break;
-          }
-        });
+      const config = window.__SUPABASE_CONFIG__ || {};
+      if (!config.projectUrl || !config.anonKey) {
+        alert("Supabase configuration missing. Please ensure .env is configured with PROJECT_URL and ANON_KEY.");
       }
 
-      function handleSessionCreated(code) {
-        currentSessionCode = code;
-        currentStage = "WAITING";
-        sessionCodeSpan.innerText = "Session Code: " + code;
+      const supabase = config.projectUrl && config.anonKey ? createClient(config.projectUrl, config.anonKey) : null;
 
-        const url = window.location.origin + "/?code=" + code;
-        studentLink.href = url;
-        studentLink.innerText = url;
+      const ui = {
+        sessionCode: document.getElementById("sessionCode"),
+        stageChip: document.getElementById("stageChip"),
+        participantLink: document.getElementById("participantLink"),
+        qrCode: document.getElementById("qrCode"),
+        participantList: document.getElementById("participantList"),
+        participantEmpty: document.getElementById("participantEmpty"),
+        historyList: document.getElementById("historyList"),
+        historyEmpty: document.getElementById("historyEmpty"),
+        questionInput: document.getElementById("questionInput"),
+        modeButtons: document.querySelectorAll(".mode-button"),
+        optionRange: document.getElementById("optionRange"),
+        optionValue: document.getElementById("optionValue"),
+        launchButton: document.getElementById("launchButton"),
+        advanceButton: document.getElementById("advanceButton"),
+        endSessionButton: document.getElementById("endSessionButton"),
+        downloadButton: document.getElementById("downloadButton"),
+        stageStatus: document.getElementById("stageStatus"),
+        responseChip: document.getElementById("responseChip"),
+        resultsGrid: document.getElementById("resultsGrid"),
+        resultsPlaceholder: document.getElementById("resultsPlaceholder"),
+        explanationsContainer: document.getElementById("explanationsContainer"),
+        toast: document.getElementById("toast"),
+      };
 
-        new QRCode(document.getElementById("qrcode"), {
-          text: url,
-          width: 128,
-          height: 128
-        });
+      const state = {
+        teacherId: generateId("teacher"),
+        sessionCode: generateSessionCode(),
+        stage: "LOBBY",
+        selectedMode: "single",
+        optionCount: parseInt(ui.optionRange.value, 10),
+        questionCounter: 0,
+        currentQuestion: null,
+        roster: [],
+        history: [],
+        channel: null,
+        supabaseReady: Boolean(supabase),
+      };
+
+      let qrInstance = null;
+
+      initialiseSessionDisplay();
+
+      if (supabase) {
+        connectToRealtime();
       }
 
-      function updateTeacherView(payload) {
-        currentStage = payload.stage;
-        currentSessionCode = payload.sessionCode;
+      ui.modeButtons.forEach((button) => {
+        button.addEventListener("click", () => selectMode(button.dataset.mode));
+      });
 
-        // Separate the joined student list from the MCQ answers
-        updateStudentList(payload.studentNames);
-        buildResultsUI(payload.questionText, payload.mcqOptions, payload.answers);
+      ui.optionRange.addEventListener("input", () => {
+        state.optionCount = parseInt(ui.optionRange.value, 10);
+        ui.optionValue.textContent = `${state.optionCount} option${state.optionCount === 1 ? "" : "s"}`;
+      });
 
-        if (currentStage === "WAITING") {
-          nextExplanationBtn.disabled = true;
-          stopQuizBtn.disabled = false;
-        } else if (currentStage === "MCQ") {
-          nextExplanationBtn.disabled = false;
-          stopQuizBtn.disabled = false;
-        } else if (currentStage === "EXPLANATION") {
-          nextExplanationBtn.disabled = true;
-          stopQuizBtn.disabled = false;
-        } else if (currentStage === "STOPPED") {
-          disableAllControls();
+      ui.launchButton.addEventListener("click", () => {
+        if (!state.supabaseReady) return;
+        if (state.stage !== "LOBBY" && state.stage !== "SUMMARY") {
+          showToast("Complete the current question before launching a new one.");
+          return;
+        }
+        startQuestion();
+      });
+
+      ui.advanceButton.addEventListener("click", () => {
+        advanceStage();
+      });
+
+      ui.endSessionButton.addEventListener("click", () => {
+        if (!confirm("End this session for everyone?")) return;
+        state.stage = "ENDED";
+        broadcastState();
+        updateInterface();
+      });
+
+      ui.downloadButton.addEventListener("click", () => {
+        if (!state.history.length) {
+          showToast("No completed questions to export yet.");
+          return;
+        }
+        downloadCsv();
+      });
+
+      function initialiseSessionDisplay() {
+        ui.sessionCode.textContent = state.sessionCode;
+        updateParticipantLink();
+        ui.stageChip.textContent = stageLabel(state.stage);
+        ui.optionValue.textContent = `${state.optionCount} options`;
+        ui.responseChip.textContent = "No responses yet";
+
+        if (window.QRCode) {
+          qrInstance = new QRCode(ui.qrCode, {
+            text: participantUrl(),
+            width: 140,
+            height: 140,
+          });
         }
       }
 
-      function updateStudentList(namesArr) {
-        studentList.innerHTML = "";
-        namesArr.forEach((name) => {
-          const li = document.createElement("li");
-          li.className = "list-group-item";
-          li.innerText = name;
-          studentList.appendChild(li);
-        });
+      function updateParticipantLink() {
+        const url = participantUrl();
+        ui.participantLink.href = url;
+        ui.participantLink.textContent = url;
+        if (qrInstance) {
+          ui.qrCode.innerHTML = "";
+          qrInstance = new QRCode(ui.qrCode, {
+            text: url,
+            width: 140,
+            height: 140,
+          });
+        }
       }
 
-      function buildResultsUI(questionText, mcqOptions, answersArr) {
-        resultsContainer.innerHTML = "";
-        if (mcqOptions < 2) return;
+      function participantUrl() {
+        return `${window.location.origin}/?code=${state.sessionCode}`;
+      }
 
-        // Group answers by chosen option
-        const optionBuckets = {};
-        for (let i = 1; i <= mcqOptions; i++) {
-          optionBuckets[i] = [];
-        }
+      async function connectToRealtime() {
+        const channelName = `session-${state.sessionCode}`;
+        state.channel = supabase.channel(channelName, {
+          config: {
+            broadcast: { ack: true, self: false },
+            presence: { key: state.teacherId },
+          },
+        });
 
-        answersArr.forEach((ans) => {
-          if (ans.mcqAnswer && optionBuckets[ans.mcqAnswer]) {
-            optionBuckets[ans.mcqAnswer].push(ans);
+        state.channel.on("broadcast", { event: "CHOICE_SUBMIT" }, ({ payload }) => {
+          if (!state.currentQuestion || !payload) return;
+          if (state.stage === "SUMMARY" || state.stage === "ENDED") return;
+          registerChoice(payload);
+        });
+
+        state.channel.on("broadcast", { event: "EXPLANATION_UPDATE" }, ({ payload }) => {
+          if (!state.currentQuestion || !payload) return;
+          if (state.currentQuestion.mode !== "multi-tier") return;
+          if (state.stage !== "EXPLANATION" && state.stage !== "SUMMARY") return;
+          registerExplanation(payload);
+        });
+
+        state.channel.on("presence", { event: "sync" }, () => {
+          updateRosterFromPresence();
+        });
+
+        const { error } = await state.channel.subscribe(async (status) => {
+          if (status === "SUBSCRIBED") {
+            await state.channel.track({
+              role: "teacher",
+              name: "Facilitator",
+              teacherId: state.teacherId,
+            });
+            broadcastState();
+            showToast("Session ready. Share the code to begin.");
           }
         });
 
-        for (let i = 1; i <= mcqOptions; i++) {
-          const col = document.createElement("div");
-          col.className = "col-sm-12 col-md-6 col-lg-4 mb-3";
+        if (error) {
+          console.error("Realtime connection error", error);
+          showToast("Unable to connect to Supabase Realtime.");
+        }
+      }
 
+      function startQuestion() {
+        state.questionCounter += 1;
+        state.currentQuestion = {
+          questionNumber: state.questionCounter,
+          questionText: ui.questionInput.value.trim(),
+          mode: state.selectedMode,
+          optionCount: state.optionCount,
+          responses: {},
+        };
+        state.stage = "CHOICE";
+        ui.questionInput.value = "";
+        ui.stageStatus.textContent = "Learners can now respond.";
+        broadcastState();
+        updateInterface();
+      }
+
+      function advanceStage() {
+        if (!state.currentQuestion) return;
+
+        if (state.currentQuestion.mode === "multi-tier") {
+          if (state.stage === "CHOICE") {
+            state.stage = "GROUP";
+            ui.stageStatus.textContent = "Learners are viewing their groups.";
+          } else if (state.stage === "GROUP") {
+            state.stage = "EXPLANATION";
+            ui.stageStatus.textContent = "Learners are sharing their reasoning.";
+          } else if (state.stage === "EXPLANATION") {
+            finishQuestion();
+          }
+        } else {
+          finishQuestion();
+        }
+
+        broadcastState();
+        updateInterface();
+      }
+
+      function finishQuestion() {
+        if (!state.currentQuestion) return;
+        state.stage = "SUMMARY";
+        ui.stageStatus.textContent = "Review the outcomes or launch another question.";
+        storeHistorySnapshot();
+        ui.downloadButton.disabled = state.history.length === 0;
+      }
+
+      function registerChoice(payload) {
+        const { studentId, name, choices } = payload;
+        if (!studentId || !Array.isArray(choices)) return;
+
+        const validChoices = Array.from(new Set(choices.map((c) => parseInt(c, 10))))
+          .filter((num) => Number.isFinite(num) && num >= 1 && num <= state.currentQuestion.optionCount)
+          .sort((a, b) => a - b);
+
+        if (!validChoices.length) return;
+
+        const responses = state.currentQuestion.responses;
+        if (!responses[studentId]) {
+          responses[studentId] = {
+            name,
+            choices: [],
+            explanation: "",
+          };
+        }
+
+        if (state.currentQuestion.mode !== "multi") {
+          responses[studentId].choices = validChoices.slice(0, 1);
+        } else {
+          responses[studentId].choices = validChoices;
+        }
+
+        updateInterface();
+        broadcastState();
+      }
+
+      function registerExplanation(payload) {
+        const { studentId, name, explanation } = payload;
+        if (!studentId) return;
+
+        const responses = state.currentQuestion.responses;
+        if (!responses[studentId]) {
+          responses[studentId] = {
+            name,
+            choices: [],
+            explanation: explanation || "",
+          };
+        } else {
+          responses[studentId].explanation = explanation || "";
+          if (name) {
+            responses[studentId].name = name;
+          }
+        }
+
+        updateInterface();
+        broadcastState();
+      }
+
+      function updateRosterFromPresence() {
+        if (!state.channel) return;
+        const presenceState = state.channel.presenceState();
+        const roster = [];
+
+        Object.values(presenceState).forEach((entries) => {
+          entries.forEach((entry) => {
+            if (entry.role === "student") {
+              roster.push({
+                name: entry.name,
+                studentId: entry.studentId,
+              });
+            }
+          });
+        });
+
+        state.roster = roster.sort((a, b) => a.name.localeCompare(b.name));
+        updateInterface();
+        broadcastState();
+      }
+
+      function selectMode(mode) {
+        state.selectedMode = mode;
+        ui.modeButtons.forEach((button) => {
+          button.classList.toggle("active", button.dataset.mode === mode);
+        });
+      }
+
+      function storeHistorySnapshot() {
+        if (!state.currentQuestion) return;
+        const snapshot = JSON.parse(JSON.stringify(state.currentQuestion));
+        state.history = state.history.filter((item) => item.questionNumber !== snapshot.questionNumber);
+        state.history.push({
+          ...snapshot,
+          completedAt: new Date().toISOString(),
+        });
+        renderHistory();
+      }
+
+      function renderHistory() {
+        ui.historyList.innerHTML = "";
+        if (!state.history.length) {
+          ui.historyEmpty.classList.remove("hidden");
+          return;
+        }
+        ui.historyEmpty.classList.add("hidden");
+
+        state.history
+          .slice()
+          .sort((a, b) => a.questionNumber - b.questionNumber)
+          .forEach((item) => {
+            const li = document.createElement("li");
+            li.innerHTML = `<strong>Q${item.questionNumber}</strong> · ${item.questionText || "Untitled"} <span class="muted" style="display:block;margin-top:4px;">${modeLabel(item.mode)} · ${item.optionCount} options</span>`;
+            ui.historyList.appendChild(li);
+          });
+      }
+
+      function updateInterface() {
+        ui.sessionCode.textContent = state.sessionCode;
+        ui.stageChip.textContent = stageLabel(state.stage, state.currentQuestion?.mode);
+        updateParticipantLink();
+        renderParticipants();
+        renderResults();
+        renderHistory();
+
+        const responses = state.currentQuestion?.responses || {};
+        const respondedCount = Object.values(responses).filter((entry) => entry.choices && entry.choices.length).length;
+        const total = state.roster.length;
+        ui.responseChip.textContent = total ? `${respondedCount}/${total} responded` : "Awaiting participants";
+
+        if (state.stage === "LOBBY") {
+          ui.stageStatus.textContent = "Ready to launch your first question.";
+        }
+
+        const activeQuestion = Boolean(state.currentQuestion);
+        ui.launchButton.disabled = activeQuestion && state.stage !== "SUMMARY";
+        ui.advanceButton.classList.toggle("hidden", !activeQuestion || state.stage === "SUMMARY" || state.stage === "ENDED");
+        ui.advanceButton.textContent = advanceButtonLabel();
+        ui.downloadButton.disabled = !state.history.length;
+      }
+
+      function renderParticipants() {
+        ui.participantList.innerHTML = "";
+        if (!state.roster.length) {
+          ui.participantEmpty.classList.remove("hidden");
+          return;
+        }
+        ui.participantEmpty.classList.add("hidden");
+
+        state.roster.forEach((participant) => {
+          const item = document.createElement("div");
+          item.className = "list-item";
+          item.innerHTML = `<span>${participant.name}</span>`;
+          ui.participantList.appendChild(item);
+        });
+      }
+
+      function renderResults() {
+        const question = state.currentQuestion;
+        if (!question) {
+          ui.resultsGrid.innerHTML = "";
+          ui.resultsPlaceholder.classList.remove("hidden");
+          ui.explanationsContainer.innerHTML = "";
+          return;
+        }
+
+        ui.resultsPlaceholder.classList.add("hidden");
+        ui.resultsGrid.innerHTML = "";
+
+        const snapshot = buildProgressSnapshot({ includeNamesDuringChoice: true });
+        const counts = snapshot.counts;
+        const total = Math.max(1, counts.reduce((sum, value) => sum + value, 0));
+
+        counts.forEach((count, index) => {
           const card = document.createElement("div");
-          card.className = "card h-100";
+          card.className = "result-card";
+          card.innerHTML = `<div class="flex-between"><strong>Option ${index + 1}</strong><span class="muted">${count} response${count === 1 ? "" : "s"}</span></div>`;
 
-          const body = document.createElement("div");
-          body.className = "card-body";
+          const progressTrack = document.createElement("div");
+          progressTrack.className = "progress-track";
+          const bar = document.createElement("div");
+          bar.className = "progress-bar";
+          bar.style.width = `${Math.round((count / total) * 100)}%`;
+          progressTrack.appendChild(bar);
+          card.appendChild(progressTrack);
 
-          const title = document.createElement("h5");
-          title.className = "card-title";
-          title.innerText = "Option " + i;
-          body.appendChild(title);
+          if (snapshot.groups && snapshot.groups[index].members.length) {
+            const groupWrap = document.createElement("div");
+            groupWrap.style.display = "flex";
+            groupWrap.style.flexWrap = "wrap";
+            groupWrap.style.gap = "8px";
+            snapshot.groups[index].members.forEach((member) => {
+              const pill = document.createElement("span");
+              pill.className = "pill";
+              pill.textContent = member.name;
+              groupWrap.appendChild(pill);
+            });
+            card.appendChild(groupWrap);
+          }
 
-          optionBuckets[i].forEach((stu) => {
-            const sub = document.createElement("div");
-            sub.className = "option-subcard";
+          ui.resultsGrid.appendChild(card);
+        });
 
-            const boldName = document.createElement("strong");
-            boldName.innerText = stu.username + ": ";
-            sub.appendChild(boldName);
+        ui.explanationsContainer.innerHTML = "";
+        if (question.mode === "multi-tier" && snapshot.explanations.length) {
+          const title = document.createElement("h3");
+          title.textContent = "Learner Explanations";
+          ui.explanationsContainer.appendChild(title);
 
-            const expl = document.createElement("span");
-            expl.innerText = stu.explanation || "(No explanation)";
-            sub.appendChild(expl);
+          snapshot.explanations.forEach((item) => {
+            const block = document.createElement("div");
+            block.className = "explanation-block";
+            block.innerHTML = `<strong>${item.name}</strong> · Option ${item.option || "–"}<p class="muted" style="margin-top:6px;white-space:pre-wrap;">${item.explanation || "(No explanation yet)"}</p>`;
+            ui.explanationsContainer.appendChild(block);
+          });
+        }
+      }
 
-            body.appendChild(sub);
+      function buildProgressSnapshot(options = {}) {
+        const includeNamesDuringChoice = Boolean(options.includeNamesDuringChoice);
+        const question = state.currentQuestion;
+        if (!question) {
+          return {
+            counts: [],
+            groups: null,
+            explanations: [],
+            submissions: {},
+          };
+        }
+
+        const counts = Array.from({ length: question.optionCount }, () => 0);
+        const groups = Array.from({ length: question.optionCount }, (_, index) => ({ option: index + 1, members: [] }));
+        const submissions = {};
+        const explanations = [];
+
+        Object.entries(question.responses).forEach(([studentId, entry]) => {
+          const choices = Array.from(new Set((entry.choices || []).map((num) => parseInt(num, 10)))).filter(
+            (num) => Number.isFinite(num) && num >= 1 && num <= question.optionCount,
+          );
+
+          if (!choices.length) return;
+
+          choices.forEach((choice) => {
+            counts[choice - 1] += 1;
+            if (question.mode === "multi-tier" && (includeNamesDuringChoice || state.stage !== "CHOICE")) {
+              groups[choice - 1].members.push({ studentId, name: entry.name || "Learner" });
+            }
           });
 
-          card.appendChild(body);
-          col.appendChild(card);
-          resultsContainer.appendChild(col);
+          submissions[studentId] = {
+            choices,
+            explanation: entry.explanation || "",
+          };
+
+          if (entry.name && (includeNamesDuringChoice || state.stage !== "CHOICE")) {
+            submissions[studentId].name = entry.name;
+          }
+
+          if (question.mode === "multi-tier" && entry.explanation && (state.stage === "EXPLANATION" || state.stage === "SUMMARY")) {
+            explanations.push({
+              studentId,
+              name: entry.name || "Learner",
+              option: choices[0] || null,
+              explanation: entry.explanation,
+            });
+          }
+        });
+
+        return {
+          counts,
+          groups: question.mode === "multi-tier" && (includeNamesDuringChoice || state.stage !== "CHOICE") ? groups : null,
+          explanations,
+          submissions,
+        };
+      }
+
+      function broadcastState() {
+        if (!state.channel) return;
+        const payload = {
+          sessionCode: state.sessionCode,
+          stage: state.stage,
+          roster: state.roster,
+          question: state.currentQuestion
+            ? {
+                number: state.currentQuestion.questionNumber,
+                text: state.currentQuestion.questionText,
+                mode: state.currentQuestion.mode,
+                optionCount: state.currentQuestion.optionCount,
+              }
+            : null,
+          progress: buildProgressSnapshot(),
+        };
+
+        state.channel.send({ type: "broadcast", event: "STATE_SYNC", payload }).catch((error) => {
+          console.error("Broadcast error", error);
+        });
+
+        if (state.stage === "ENDED") {
+          state.channel.send({
+            type: "broadcast",
+            event: "SESSION_ENDED",
+            payload: { message: "The facilitator has concluded the session." },
+          });
         }
       }
 
-      // Buttons
-      startOrNextBtn.addEventListener("click", () => {
-        if (!currentSessionCode || currentStage === "STOPPED") return;
-
-        const qText = questionText.value.trim();
-        const opts = getSelectedOptions();
-
-        socket.send(
-          JSON.stringify({
-            type: "TEACHER_START_MCQ",
-            payload: {
-              sessionCode: currentSessionCode,
-              questionText: qText,
-              options: opts
-            }
-          })
-        );
-
-        questionText.value = "";
-        if (isFirstQuestion) {
-          isFirstQuestion = false;
-          startOrNextBtn.innerText = "Next Question";
+      function advanceButtonLabel() {
+        if (!state.currentQuestion) return "Advance";
+        if (state.currentQuestion.mode === "multi-tier") {
+          if (state.stage === "CHOICE") return "Move to Grouping";
+          if (state.stage === "GROUP") return "Open Explanations";
+          if (state.stage === "EXPLANATION") return "Show Summary";
         }
-      });
-
-      nextExplanationBtn.addEventListener("click", () => {
-        if (!currentSessionCode) return;
-        socket.send(
-          JSON.stringify({
-            type: "TEACHER_NEXT_EXPLANATION",
-            payload: { sessionCode: currentSessionCode }
-          })
-        );
-      });
-
-      stopQuizBtn.addEventListener("click", () => {
-        if (!currentSessionCode) return;
-        socket.send(
-          JSON.stringify({
-            type: "TEACHER_STOP_QUIZ",
-            payload: { sessionCode: currentSessionCode }
-          })
-        );
-      });
-
-      downloadCsvBtn.addEventListener("click", () => {
-        if (!currentSessionCode) return;
-        socket.send(
-          JSON.stringify({
-            type: "TEACHER_DOWNLOAD_CSV",
-            payload: { sessionCode: currentSessionCode }
-          })
-        );
-      });
-
-      function disableAllControls() {
-        startOrNextBtn.disabled = true;
-        nextExplanationBtn.disabled = true;
-        stopQuizBtn.disabled = true;
+        if (state.stage === "CHOICE") return "Show Summary";
+        return "Advance";
       }
 
-      function getSelectedOptions() {
-        if (document.getElementById("opt3").checked) return 3;
-        if (document.getElementById("opt4").checked) return 4;
-        return 2;
+      function stageLabel(stage, mode) {
+        switch (stage) {
+          case "CHOICE":
+            return mode === "multi-tier" ? "Select" : "Respond";
+          case "GROUP":
+            return "Group";
+          case "EXPLANATION":
+            return "Explain";
+          case "SUMMARY":
+            return "Summary";
+          case "ENDED":
+            return "Session Ended";
+          default:
+            return "Lobby";
+        }
       }
 
-      function triggerDownload(csvString, filename) {
-        const blob = new Blob([csvString], { type: "text/csv" });
+      function modeLabel(mode) {
+        switch (mode) {
+          case "single":
+            return "Single response";
+          case "multi":
+            return "Multi-response";
+          case "multi-tier":
+            return "Multi-tier";
+          default:
+            return "";
+        }
+      }
+
+      function showToast(message) {
+        if (!message) return;
+        ui.toast.textContent = message;
+        ui.toast.classList.add("show");
+        setTimeout(() => ui.toast.classList.remove("show"), 2600);
+      }
+
+      function downloadCsv() {
+        const rows = [["Question #", "Question Text", "Mode", "Student", "Choices", "Explanation"]];
+
+        state.history.forEach((question) => {
+          Object.values(question.responses || {}).forEach((response) => {
+            rows.push([
+              question.questionNumber,
+              question.questionText || "",
+              modeLabel(question.mode),
+              response.name || "",
+              (response.choices || []).map((c) => `Option ${c}`).join("; "),
+              response.explanation || "",
+            ]);
+          });
+        });
+
+        const csv = rows
+          .map((row) => row.map((value) => `"${String(value).replace(/"/g, '""')}"`).join(","))
+          .join("\n");
+
+        const blob = new Blob([csv], { type: "text/csv" });
         const url = URL.createObjectURL(blob);
-
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
+        const link = document.createElement("a");
+        const timestamp = new Date().toISOString().replace(/[:T]/g, "-").split(".")[0];
+        link.href = url;
+        link.download = `mcq_session_${state.sessionCode}_${timestamp}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        showToast("CSV downloaded.");
       }
 
-      window.addEventListener("beforeunload", () => {
-        if (currentSessionCode && currentStage !== "STOPPED") {
-          socket.send(
-            JSON.stringify({
-              type: "TEACHER_CLOSE_PAGE",
-              payload: { sessionCode: currentSessionCode }
-            })
-          );
+      function generateSessionCode() {
+        const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        let result = "";
+        for (let i = 0; i < 6; i++) {
+          result += chars[Math.floor(Math.random() * chars.length)];
         }
-      });
+        return result;
+      }
 
-      window.addEventListener("load", connectWebSocket);
+      function generateId(prefix) {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+          return `${prefix}-${crypto.randomUUID()}`;
+        }
+        return `${prefix}-${Math.random().toString(16).slice(2)}${Date.now()}`;
+      }
     </script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,279 +1,937 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Student Console</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Collaborative MCQ Workspace – Student</title>
     <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
     />
     <style>
+      :root {
+        color-scheme: light;
+        --brand: #4b74ff;
+        --brand-accent: #2f4fdb;
+        --bg: #f5f7fb;
+        --card: #ffffff;
+        --text: #21263c;
+        --muted: #6e7591;
+        --success: #1c9c6d;
+        --danger: #cc3a51;
+        --border-radius: 18px;
+        --shadow: 0 16px 40px rgba(29, 49, 85, 0.08);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        background: linear-gradient(120deg, #d4fc79 0%, #96e6a1 100%);
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at 20% 20%, rgba(75, 116, 255, 0.14), transparent 55%),
+          radial-gradient(circle at 80% 0%, rgba(28, 156, 109, 0.12), transparent 45%),
+          var(--bg);
+        color: var(--text);
         min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px 16px;
       }
-      .hero-section {
-        background: #fff;
-        padding: 1.5rem;
-        border-radius: 10px;
-        margin-top: 2rem;
-        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+
+      .app-shell {
+        width: min(1080px, 100%);
+        display: grid;
+        gap: 24px;
       }
-      .fade-in {
-        animation: fadein 0.6s;
+
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: rgba(255, 255, 255, 0.75);
+        backdrop-filter: blur(20px);
+        border-radius: var(--border-radius);
+        padding: 20px 28px;
+        box-shadow: var(--shadow);
       }
-      @keyframes fadein {
-        from {opacity:0;}
-        to {opacity:1;}
+
+      header .title-group h1 {
+        margin: 0;
+        font-size: 1.6rem;
+        font-weight: 700;
+      }
+
+      header .title-group p {
+        margin: 4px 0 0;
+        color: var(--muted);
+      }
+
+      header .stage-chip {
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-weight: 600;
+        background: rgba(75, 116, 255, 0.12);
+        color: var(--brand-accent);
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      header .stage-chip span {
+        font-size: 1.1rem;
+      }
+
+      .card {
+        background: var(--card);
+        border-radius: var(--border-radius);
+        padding: 28px;
+        box-shadow: var(--shadow);
+      }
+
+      .card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        margin-bottom: 8px;
+      }
+
+      .card p.subtitle {
+        margin-top: 0;
+        margin-bottom: 24px;
+        color: var(--muted);
+      }
+
+      .grid-two {
+        display: grid;
+        gap: 24px;
+      }
+
+      @media (min-width: 900px) {
+        .grid-two {
+          grid-template-columns: 3fr 2fr;
+        }
+      }
+
+      label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      textarea {
+        width: 100%;
+        border-radius: 12px;
+        border: 1px solid rgba(33, 38, 60, 0.12);
+        padding: 12px 16px;
+        font-size: 1rem;
+        font-family: inherit;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      input[type="text"]:focus,
+      textarea:focus {
+        outline: none;
+        border-color: rgba(75, 116, 255, 0.45);
+        box-shadow: 0 0 0 4px rgba(75, 116, 255, 0.15);
+      }
+
+      textarea {
+        resize: vertical;
+        min-height: 120px;
+      }
+
+      button {
+        border: none;
+        border-radius: 12px;
+        font-size: 1rem;
+        font-weight: 600;
+        padding: 12px 20px;
+        cursor: pointer;
+        transition: transform 0.1s ease, box-shadow 0.2s ease, background 0.2s ease;
+        font-family: inherit;
+      }
+
+      button.primary {
+        background: linear-gradient(135deg, var(--brand) 0%, var(--brand-accent) 100%);
+        color: #fff;
+        box-shadow: 0 12px 24px rgba(75, 116, 255, 0.24);
+      }
+
+      button.primary:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+        box-shadow: none;
+      }
+
+      button.secondary {
+        background: rgba(33, 38, 60, 0.06);
+        color: var(--text);
+      }
+
+      button:hover:not(:disabled) {
+        transform: translateY(-1px);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      .status-banner {
+        border-radius: 12px;
+        padding: 14px 16px;
+        background: rgba(75, 116, 255, 0.12);
+        color: var(--brand-accent);
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .status-banner.error {
+        background: rgba(204, 58, 81, 0.12);
+        color: var(--danger);
+      }
+
+      .status-banner.success {
+        background: rgba(28, 156, 109, 0.12);
+        color: var(--success);
+      }
+
+      .option-list {
+        display: grid;
+        gap: 12px;
+        margin-top: 16px;
+      }
+
+      .option-tile {
+        border: 1px solid rgba(33, 38, 60, 0.12);
+        border-radius: 14px;
+        padding: 16px 18px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        transition: border 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .option-tile input {
+        width: 20px;
+        height: 20px;
+      }
+
+      .option-tile.selected {
+        border-color: rgba(75, 116, 255, 0.6);
+        background: rgba(75, 116, 255, 0.08);
+        box-shadow: 0 8px 18px rgba(75, 116, 255, 0.18);
+      }
+
+      .sub-card {
+        border: 1px solid rgba(33, 38, 60, 0.08);
+        border-radius: 12px;
+        padding: 16px;
+        background: rgba(255, 255, 255, 0.72);
+      }
+
+      .group-members {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .pill {
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(33, 38, 60, 0.08);
+        font-size: 0.9rem;
+      }
+
+      .summary-grid {
+        display: grid;
+        gap: 16px;
+      }
+
+      @media (min-width: 768px) {
+        .summary-grid {
+          grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+      }
+
+      .progress-track {
+        width: 100%;
+        height: 8px;
+        border-radius: 999px;
+        background: rgba(33, 38, 60, 0.08);
+        overflow: hidden;
+        margin-top: 8px;
+      }
+
+      .progress-bar {
+        height: 100%;
+        border-radius: 999px;
+        background: linear-gradient(135deg, var(--brand) 0%, var(--brand-accent) 100%);
+        transition: width 0.4s ease;
+      }
+
+      .muted {
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      ul.roster {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      ul.roster li {
+        background: rgba(33, 38, 60, 0.08);
+        padding: 6px 12px;
+        border-radius: 999px;
+        font-size: 0.9rem;
       }
     </style>
   </head>
-  <body class="p-3">
-    <div class="container fade-in">
-      <div class="hero-section">
-        <h1 class="mb-4">Student Console</h1>
+  <body>
+    <div class="app-shell">
+      <header>
+        <div class="title-group">
+          <h1>Collaborative MCQ Workspace</h1>
+          <p>Join the live session, respond, discuss, and explain with your peers.</p>
+        </div>
+        <div class="stage-chip">
+          <small>Stage</small>
+          <span id="stageLabel">Lobby</span>
+        </div>
+      </header>
 
-        <!-- Join form -->
-        <div id="joinArea">
+      <div class="grid-two">
+        <section id="joinCard" class="card">
+          <h2>Join a Session</h2>
+          <p class="subtitle">
+            Enter the session code provided by your facilitator and let us know your name.
+          </p>
           <div class="form-group">
-            <label for="sessionCodeInput">Session Code:</label>
+            <label for="codeInput">Session Code</label>
             <input
+              id="codeInput"
               type="text"
-              id="sessionCodeInput"
-              class="form-control"
               placeholder="ABC123"
+              autocomplete="off"
+              maxlength="12"
             />
           </div>
           <div class="form-group">
-            <label for="usernameInput">Your Name:</label>
+            <label for="nameInput">Your Name</label>
             <input
+              id="nameInput"
               type="text"
-              id="usernameInput"
-              class="form-control"
-              placeholder="e.g. Alice"
+              placeholder="e.g. Taylor"
+              autocomplete="name"
             />
           </div>
-          <button id="joinBtn" class="btn btn-primary btn-block mt-3">
-            Join Session
-          </button>
-        </div>
+          <button id="joinButton" class="primary" type="button">Join Session</button>
+          <div id="joinFeedback" class="status-banner hidden" role="status"></div>
+        </section>
 
-        <!-- Waiting notice -->
-        <div id="waitingArea" class="mt-4" style="display: none;">
-          <h4>Waiting for quiz to start...</h4>
-        </div>
-
-        <!-- MCQ area -->
-        <div id="mcqArea" class="mt-4" style="display: none;">
-          <h4 id="questionTitle"></h4>
-          <div id="optionsContainer" class="my-3"></div>
-          <button id="submitMcqBtn" class="btn btn-success btn-block">
-            Submit
-          </button>
-          <p
-            id="chosenMsg"
-            class="text-success mt-3"
-            style="display: none;"
-          ></p>
-        </div>
-
-        <!-- Explanation area -->
-        <div id="explanationArea" class="mt-4" style="display: none;">
-          <h4>Explain your reasoning (auto-updates)</h4>
-          <textarea
-            id="explanationInput"
-            class="form-control"
-            rows="3"
-            placeholder="Type your explanation here..."
-          ></textarea>
-        </div>
+        <section id="statusCard" class="card hidden">
+          <h2>Live Session Details</h2>
+          <p class="subtitle">Stay in sync with the facilitator and your peers.</p>
+          <div class="sub-card">
+            <strong>Session Code:</strong>
+            <div id="sessionCodeDisplay" style="font-size:1.4rem;font-weight:700;margin-top:4px;letter-spacing:0.08em;"></div>
+          </div>
+          <div class="sub-card" style="margin-top:16px;">
+            <strong>Participants</strong>
+            <ul id="rosterList" class="roster" style="margin-top:12px;"></ul>
+            <p id="rosterEmpty" class="muted" style="margin-top:12px;">You're the first one here—welcome!</p>
+          </div>
+          <div id="statusBanner" class="status-banner" style="margin-top:16px;">
+            Waiting for the facilitator to launch a question…
+          </div>
+        </section>
       </div>
+
+      <section id="experienceCard" class="card hidden">
+        <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px;flex-wrap:wrap;">
+          <div>
+            <h2 id="questionHeading">Awaiting the next question…</h2>
+            <p id="questionMeta" class="muted" style="margin-top:4px;"></p>
+          </div>
+          <div id="responseSummary" class="sub-card hidden" style="min-width:220px;">
+            <strong>Response Progress</strong>
+            <p id="responseStats" class="muted" style="margin:8px 0 0;"></p>
+          </div>
+        </div>
+
+        <div id="choiceArea" class="sub-card" style="margin-top:24px;">
+          <div style="display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap;">
+            <div>
+              <strong id="choiceTitle">Select your option(s)</strong>
+              <p id="choiceHint" class="muted" style="margin-top:4px;">Make your selection and submit when ready.</p>
+            </div>
+            <button id="submitChoice" class="primary" type="button">Submit</button>
+          </div>
+          <div id="optionsContainer" class="option-list"></div>
+          <p id="choiceFeedback" class="muted" style="margin-top:12px;"></p>
+        </div>
+
+        <div id="groupArea" class="sub-card hidden" style="margin-top:24px;">
+          <strong>Your Discussion Group</strong>
+          <p id="groupDescription" class="muted" style="margin-top:6px;"></p>
+          <div id="groupMembers" class="group-members" style="margin-top:14px;"></div>
+        </div>
+
+        <div id="explanationArea" class="sub-card hidden" style="margin-top:24px;">
+          <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;">
+            <strong>Share your reasoning</strong>
+            <span id="explanationStatus" class="muted"></span>
+          </div>
+          <textarea id="explanationInput" placeholder="Capture the thinking behind your choice…"></textarea>
+        </div>
+
+        <div id="summaryArea" class="sub-card hidden" style="margin-top:24px;">
+          <strong>Session Summary</strong>
+          <p class="muted" style="margin-top:6px;">See how the community responded.</p>
+          <div id="summaryGrid" class="summary-grid" style="margin-top:16px;"></div>
+          <div id="explanationList" style="margin-top:24px;"></div>
+        </div>
+      </section>
     </div>
 
-    <script>
-      let socket;
-      let studentId = null;
-      let sessionCode = null;
-      let selectedOption = null;
+    <script src="/env.js"></script>
+    <script type="module">
+      import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-      const joinArea = document.getElementById("joinArea");
-      const waitingArea = document.getElementById("waitingArea");
-      const mcqArea = document.getElementById("mcqArea");
-      const questionTitle = document.getElementById("questionTitle");
+      const stageLabel = document.getElementById("stageLabel");
+      const joinButton = document.getElementById("joinButton");
+      const joinCard = document.getElementById("joinCard");
+      const statusCard = document.getElementById("statusCard");
+      const experienceCard = document.getElementById("experienceCard");
+      const joinFeedback = document.getElementById("joinFeedback");
+      const statusBanner = document.getElementById("statusBanner");
+      const sessionCodeDisplay = document.getElementById("sessionCodeDisplay");
+      const rosterList = document.getElementById("rosterList");
+      const rosterEmpty = document.getElementById("rosterEmpty");
+      const questionHeading = document.getElementById("questionHeading");
+      const questionMeta = document.getElementById("questionMeta");
       const optionsContainer = document.getElementById("optionsContainer");
-      const chosenMsg = document.getElementById("chosenMsg");
+      const submitChoice = document.getElementById("submitChoice");
+      const choiceTitle = document.getElementById("choiceTitle");
+      const choiceHint = document.getElementById("choiceHint");
+      const choiceFeedback = document.getElementById("choiceFeedback");
+      const groupArea = document.getElementById("groupArea");
+      const groupDescription = document.getElementById("groupDescription");
+      const groupMembers = document.getElementById("groupMembers");
       const explanationArea = document.getElementById("explanationArea");
-
-      const sessionCodeInput = document.getElementById("sessionCodeInput");
-      const usernameInput = document.getElementById("usernameInput");
-      const joinBtn = document.getElementById("joinBtn");
-      const submitMcqBtn = document.getElementById("submitMcqBtn");
       const explanationInput = document.getElementById("explanationInput");
+      const explanationStatus = document.getElementById("explanationStatus");
+      const summaryArea = document.getElementById("summaryArea");
+      const summaryGrid = document.getElementById("summaryGrid");
+      const explanationList = document.getElementById("explanationList");
+      const responseSummary = document.getElementById("responseSummary");
+      const responseStats = document.getElementById("responseStats");
+      const choiceArea = document.getElementById("choiceArea");
+      const codeInput = document.getElementById("codeInput");
+      const nameInput = document.getElementById("nameInput");
 
-      // If ?code=xxx, pre-fill
-      const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.has("code")) {
-        sessionCodeInput.value = urlParams.get("code");
+      const state = {
+        supabase: null,
+        channel: null,
+        joined: false,
+        studentId: generateId("student"),
+        name: "",
+        sessionCode: "",
+        stage: "LOBBY",
+        currentQuestion: null,
+        progress: null,
+        roster: [],
+        selectedChoices: new Set(),
+        explanationDraft: "",
+      };
+
+      const config = window.__SUPABASE_CONFIG__ || {};
+      if (!config.projectUrl || !config.anonKey) {
+        displayJoinFeedback("Supabase configuration is missing. Please check the server setup.", true);
+        joinButton.disabled = true;
+      } else {
+        state.supabase = createClient(config.projectUrl, config.anonKey);
       }
 
-      function connectWebSocket() {
-        socket = new WebSocket(
-          window.location.origin.replace(/^http/, "ws")
-        );
+      // Prefill session code if provided via URL
+      const params = new URLSearchParams(window.location.search);
+      if (params.has("code")) {
+        codeInput.value = params.get("code");
+      }
 
-        socket.addEventListener("open", () => {
-          console.log("Student connected via WebSocket");
+      joinButton.addEventListener("click", async () => {
+        if (!state.supabase || state.joined) return;
+
+        const code = codeInput.value.trim().toUpperCase();
+        const name = nameInput.value.trim();
+        if (!code || !name) {
+          displayJoinFeedback("Please provide both the session code and your name.", true);
+          return;
+        }
+
+        joinButton.disabled = true;
+        displayJoinFeedback("Connecting to the live session…", false, false);
+
+        try {
+          state.sessionCode = code;
+          state.name = name;
+          await connectToChannel();
+        } catch (error) {
+          console.error(error);
+          state.sessionCode = "";
+          displayJoinFeedback("We couldn't join that session. Please check the code and try again.", true);
+          joinButton.disabled = false;
+        }
+      });
+
+      submitChoice.addEventListener("click", async () => {
+        if (!state.channel || !state.currentQuestion) return;
+
+        const mode = state.currentQuestion.mode;
+        const choices = Array.from(state.selectedChoices);
+
+        if (!choices.length) {
+          choiceFeedback.textContent = "Select at least one option before submitting.";
+          return;
+        }
+
+        if (mode !== "multi" && choices.length > 1) {
+          choiceFeedback.textContent = "Only one option can be selected for this activity.";
+          return;
+        }
+
+        const response = await state.channel.send({
+          type: "broadcast",
+          event: "CHOICE_SUBMIT",
+          payload: {
+            studentId: state.studentId,
+            name: state.name,
+            choices,
+            submittedAt: new Date().toISOString(),
+          },
         });
 
-        socket.addEventListener("message", (evt) => {
-          const data = JSON.parse(evt.data);
-          switch (data.type) {
-            case "JOINED_SESSION":
-              studentId = data.payload.studentId;
-              sessionCode = data.payload.sessionCode;
-              handleJoined(data.payload.stage);
-              break;
-            case "MCQ_STARTED":
-              showMcq(data.payload.questionText, data.payload.options);
-              break;
-            case "SHOW_EXPLANATION_INPUT":
-              showExplanation();
-              break;
-            case "QUIZ_STOPPED":
-              alert("Quiz has been stopped by the teacher.");
-              socket.close();
-              location.reload();
-              break;
-            case "ERROR":
-              alert(data.payload.message);
-              break;
+        if (response?.status === "ok") {
+          choiceFeedback.textContent = "Your response is saved. You can resubmit if you change your mind before the next stage.";
+        } else {
+          choiceFeedback.textContent = "We couldn't deliver your response. Please try again.";
+        }
+      });
+
+      const debouncedExplanation = debounce(async (value) => {
+        if (!state.channel || state.stage !== "EXPLANATION") return;
+        state.explanationDraft = value;
+
+        await state.channel.send({
+          type: "broadcast",
+          event: "EXPLANATION_UPDATE",
+          payload: {
+            studentId: state.studentId,
+            name: state.name,
+            explanation: value,
+            updatedAt: new Date().toISOString(),
+          },
+        });
+      }, 400);
+
+      explanationInput.addEventListener("input", (event) => {
+        debouncedExplanation(event.target.value);
+      });
+
+      async function connectToChannel() {
+        const channelName = `session-${state.sessionCode}`;
+        state.channel = state.supabase.channel(channelName, {
+          config: {
+            broadcast: { self: false },
+            presence: { key: state.studentId },
+          },
+        });
+
+        state.channel.on("broadcast", { event: "STATE_SYNC" }, ({ payload }) => {
+          applyState(payload);
+        });
+
+        state.channel.on("broadcast", { event: "SESSION_ENDED" }, ({ payload }) => {
+          stageLabel.textContent = "Session Ended";
+          statusBanner.textContent = payload?.message || "The facilitator has closed this session.";
+          statusBanner.classList.add("error");
+          explanationInput.disabled = true;
+          submitChoice.disabled = true;
+        });
+
+        const { error } = await state.channel.subscribe(async (status) => {
+          if (status === "SUBSCRIBED") {
+            await state.channel.track({
+              role: "student",
+              name: state.name,
+              studentId: state.studentId,
+            });
+            onJoinSuccess();
           }
         });
+
+        if (error) {
+          throw error;
+        }
       }
 
-      joinBtn.addEventListener("click", () => {
-        const code = sessionCodeInput.value.trim().toUpperCase();
-        const uname = usernameInput.value.trim();
-        if (!code || !uname) {
-          alert("Please enter both session code and your name.");
+      function onJoinSuccess() {
+        state.joined = true;
+        joinCard.classList.add("hidden");
+        statusCard.classList.remove("hidden");
+        experienceCard.classList.remove("hidden");
+        displayJoinFeedback("Successfully connected!", false, true);
+        joinButton.disabled = false;
+        updateRoster([]);
+      }
+
+      function applyState(payload) {
+        if (!payload) return;
+
+        state.stage = payload.stage || "LOBBY";
+        state.roster = payload.roster || [];
+        state.sessionCode = payload.sessionCode || state.sessionCode;
+        state.currentQuestion = payload.question || null;
+        state.progress = payload.progress || null;
+
+        stageLabel.textContent = stageLabelFor(state.stage, state.currentQuestion?.mode);
+        sessionCodeDisplay.textContent = state.sessionCode || "";
+        updateRoster(state.roster);
+        updateProgressStats(state.progress);
+
+        if (!state.currentQuestion) {
+          questionHeading.textContent = "Awaiting the next question…";
+          questionMeta.textContent = "You'll be notified as soon as the facilitator launches a new prompt.";
+          choiceArea.classList.add("hidden");
+          groupArea.classList.add("hidden");
+          explanationArea.classList.add("hidden");
+          summaryArea.classList.add("hidden");
           return;
         }
-        socket.send(
-          JSON.stringify({
-            type: "STUDENT_JOIN_SESSION",
-            payload: {
-              sessionCode: code,
-              username: uname
-            }
-          })
-        );
-      });
 
-      function handleJoined(stage) {
-        joinArea.style.display = "none";
-        if (stage === "WAITING") {
-          waitingArea.style.display = "block";
-        } else if (stage === "MCQ") {
-          // teacher might already be in MCQ stage
-          waitingArea.style.display = "block"; 
-        } else if (stage === "EXPLANATION") {
-          waitingArea.style.display = "none";
-          mcqArea.style.display = "none";
-          explanationArea.style.display = "block";
+        const q = state.currentQuestion;
+        questionHeading.textContent = q.text || "Untitled question";
+        questionMeta.textContent = `Question ${q.number} · ${modeLabel(q.mode)} · ${q.optionCount} options`;
+
+        if (state.stage === "CHOICE") {
+          renderChoiceInterface(q);
+          groupArea.classList.add("hidden");
+          explanationArea.classList.add("hidden");
+          summaryArea.classList.add("hidden");
+          statusBanner.textContent = "Respond to the question, then await further instructions.";
+        } else if (state.stage === "GROUP") {
+          renderChoiceInterface(q, true);
+          renderGroupArea(q);
+          explanationArea.classList.add("hidden");
+          summaryArea.classList.add("hidden");
+          statusBanner.textContent = "You're grouped based on your selections. Connect with your peers.";
+        } else if (state.stage === "EXPLANATION") {
+          renderGroupArea(q);
+          explanationArea.classList.remove("hidden");
+          renderExplanationState();
+          summaryArea.classList.add("hidden");
+          statusBanner.textContent = "Share the thinking behind your choice.";
+        } else if (state.stage === "SUMMARY") {
+          renderSummary();
+          explanationArea.classList.add("hidden");
+          statusBanner.textContent = "Review the collective outcomes.";
+        } else if (state.stage === "ENDED") {
+          statusBanner.textContent = "The facilitator has closed this session.";
+          statusBanner.classList.add("error");
+          choiceArea.classList.add("hidden");
+          groupArea.classList.add("hidden");
+          explanationArea.classList.add("hidden");
+          summaryArea.classList.add("hidden");
         }
       }
 
-      function showMcq(qText, numOptions) {
-        // Clear old inputs from any previous question
-        explanationInput.value = "";
+      function renderChoiceInterface(question, isReadOnly = false) {
+        choiceArea.classList.remove("hidden");
+        choiceTitle.textContent = question.mode === "multi" ? "Select all options that apply" : "Choose the option that best matches your thinking";
+        choiceHint.textContent = isReadOnly
+          ? "Selections are now closed while we organise groups."
+          : question.mode === "multi"
+          ? "You can select multiple options. Submit to let the facilitator know you're done."
+          : "Select exactly one option. You can resubmit before the next stage.";
 
-        waitingArea.style.display = "none";
-        mcqArea.style.display = "block";
-        explanationArea.style.display = "none";
+        if (isReadOnly) {
+          submitChoice.disabled = true;
+        } else {
+          submitChoice.disabled = false;
+        }
 
-        chosenMsg.style.display = "none";
-        submitMcqBtn.disabled = false;
-        selectedOption = null;
+        const previousSelection = state.progress?.submissions?.[state.studentId]?.choices || [];
+        state.selectedChoices = new Set(previousSelection);
 
-        questionTitle.innerText = qText || "(No question provided)";
         optionsContainer.innerHTML = "";
+        for (let i = 1; i <= question.optionCount; i++) {
+          const optionTile = document.createElement("label");
+          optionTile.className = "option-tile";
 
-        for (let i = 1; i <= numOptions; i++) {
-          const div = document.createElement("div");
-          div.className = "form-check";
+          const control = document.createElement("input");
+          control.type = question.mode === "multi" ? "checkbox" : "radio";
+          control.name = "optionChoice";
+          control.value = String(i);
+          control.disabled = isReadOnly;
 
-          const radio = document.createElement("input");
-          radio.type = "radio";
-          radio.name = "mcqOption";
-          radio.value = i;
-          radio.className = "form-check-input";
-          radio.id = "option" + i;
+          const optionLabel = document.createElement("div");
+          optionLabel.style.fontWeight = "600";
+          optionLabel.textContent = `Option ${i}`;
 
-          radio.addEventListener("change", () => {
-            selectedOption = i;
+          if (state.selectedChoices.has(i)) {
+            optionTile.classList.add("selected");
+            control.checked = true;
+          }
+
+          control.addEventListener("change", () => {
+            if (question.mode === "multi") {
+              if (control.checked) {
+                state.selectedChoices.add(i);
+              } else {
+                state.selectedChoices.delete(i);
+              }
+            } else {
+              state.selectedChoices = new Set([i]);
+              document.querySelectorAll('input[name="optionChoice"]').forEach((input) => {
+                if (input !== control) {
+                  const parent = input.closest(".option-tile");
+                  parent && parent.classList.remove("selected");
+                  input.checked = false;
+                }
+              });
+            }
+
+            if (control.checked) {
+              optionTile.classList.add("selected");
+            } else {
+              optionTile.classList.remove("selected");
+            }
           });
 
-          const label = document.createElement("label");
-          label.className = "form-check-label";
-          label.setAttribute("for", "option" + i);
-          label.innerText = "Option " + i;
-
-          div.appendChild(radio);
-          div.appendChild(label);
-          optionsContainer.appendChild(div);
+          optionTile.appendChild(optionLabel);
+          optionTile.appendChild(control);
+          optionsContainer.appendChild(optionTile);
         }
+
+        choiceFeedback.textContent = previousSelection.length
+          ? `Submitted: ${previousSelection.map((opt) => `Option ${opt}`).join(", ")}`
+          : "";
       }
 
-      submitMcqBtn.addEventListener("click", () => {
-        if (!selectedOption) {
-          alert("Please select an option first!");
+      function renderGroupArea(question) {
+        const mode = question.mode;
+        if (mode !== "multi-tier" || !state.progress?.groups) {
+          groupArea.classList.add("hidden");
           return;
         }
-        socket.send(
-          JSON.stringify({
-            type: "STUDENT_SUBMIT_MCQ",
-            payload: {
-              sessionCode,
-              studentId,
-              answer: selectedOption
-            }
-          })
-        );
-        // lock
-        submitMcqBtn.disabled = true;
-        const radios = optionsContainer.querySelectorAll("input[type=radio]");
-        radios.forEach((r) => (r.disabled = true));
 
-        chosenMsg.innerText = `You chose Option ${selectedOption}. Please wait for the next part.`;
-        chosenMsg.style.display = "block";
-      });
+        groupArea.classList.remove("hidden");
+        const mySubmission = state.progress.submissions?.[state.studentId];
+        const myChoice = mySubmission?.choices?.[0];
+        if (!myChoice) {
+          groupDescription.textContent = "We're arranging groups based on your selections.";
+          groupMembers.innerHTML = "";
+          return;
+        }
 
-      function showExplanation() {
-        // Clear old explanation from previous question
-        explanationInput.value = "";
+        const groupInfo = state.progress.groups.find((group) => group.option === myChoice);
+        if (!groupInfo) {
+          groupDescription.textContent = `We couldn't find your group for Option ${myChoice} yet.`;
+          groupMembers.innerHTML = "";
+          return;
+        }
 
-        mcqArea.style.display = "none";
-        waitingArea.style.display = "none";
-        explanationArea.style.display = "block";
+        groupDescription.textContent = `You're collaborating with peers who chose Option ${myChoice}.`;
+        groupMembers.innerHTML = "";
+
+        if (!groupInfo.members.length) {
+          groupMembers.innerHTML = `<span class="pill">You're the first one in this group!</span>`;
+        } else {
+          groupInfo.members.forEach((member) => {
+            const pill = document.createElement("span");
+            pill.className = "pill";
+            pill.textContent = member.name === state.name ? `${member.name} (You)` : member.name;
+            groupMembers.appendChild(pill);
+          });
+        }
       }
 
-      // Real-time explanation
-      explanationInput.addEventListener("input", (e) => {
-        if (!sessionCode || !studentId) return;
-        const text = e.target.value;
-        socket.send(
-          JSON.stringify({
-            type: "STUDENT_EXPLANATION_UPDATE",
-            payload: {
-              sessionCode,
-              studentId,
-              explanation: text
-            }
-          })
-        );
-      });
+      function renderExplanationState() {
+        const mySubmission = state.progress?.submissions?.[state.studentId];
+        if (!mySubmission) {
+          explanationInput.value = "";
+          explanationStatus.textContent = "Waiting for your selection.";
+          explanationInput.disabled = true;
+          return;
+        }
 
-      window.addEventListener("load", connectWebSocket);
+        explanationInput.disabled = false;
+        explanationInput.value = mySubmission.explanation || state.explanationDraft || "";
+        explanationStatus.textContent = mySubmission.explanation
+          ? "Saved"
+          : "Auto-saves as you type";
+      }
+
+      function renderSummary() {
+        if (!state.progress) return;
+
+        choiceArea.classList.add("hidden");
+        groupArea.classList.add("hidden");
+        summaryArea.classList.remove("hidden");
+
+        summaryGrid.innerHTML = "";
+        const counts = state.progress.counts || [];
+        const total = counts.reduce((sum, c) => sum + c, 0) || 1;
+
+        counts.forEach((count, index) => {
+          const card = document.createElement("div");
+          card.className = "sub-card";
+          const label = document.createElement("div");
+          label.innerHTML = `<strong>Option ${index + 1}</strong>`;
+
+          const value = document.createElement("div");
+          value.style.marginTop = "8px";
+          value.innerHTML = `<span style="font-size:1.8rem;font-weight:700;">${count}</span> <span class="muted">responses</span>`;
+
+          const progressTrack = document.createElement("div");
+          progressTrack.className = "progress-track";
+          const bar = document.createElement("div");
+          bar.className = "progress-bar";
+          bar.style.width = `${Math.round((count / total) * 100)}%`;
+          progressTrack.appendChild(bar);
+
+          card.appendChild(label);
+          card.appendChild(value);
+          card.appendChild(progressTrack);
+          summaryGrid.appendChild(card);
+        });
+
+        explanationList.innerHTML = "";
+        if (state.currentQuestion.mode === "multi-tier") {
+          const explanations = state.progress.explanations || [];
+          if (!explanations.length) {
+            explanationList.innerHTML = `<p class="muted">Explanations will appear here once shared.</p>`;
+          } else {
+            const title = document.createElement("h3");
+            title.textContent = "Shared Reasoning";
+            explanationList.appendChild(title);
+
+            explanations.forEach((item) => {
+              const block = document.createElement("div");
+              block.className = "sub-card";
+              block.style.marginTop = "12px";
+              block.innerHTML = `<strong>${item.name}</strong> · Option ${item.option || "–"}<p class="muted" style="margin-top:8px;white-space:pre-wrap;">${item.explanation}</p>`;
+              explanationList.appendChild(block);
+            });
+          }
+        } else {
+          explanationList.innerHTML = "";
+        }
+      }
+
+      function updateRoster(roster) {
+        rosterList.innerHTML = "";
+        if (!roster || !roster.length) {
+          rosterEmpty.classList.remove("hidden");
+          return;
+        }
+        rosterEmpty.classList.add("hidden");
+
+        roster
+          .filter((member) => member && member.name)
+          .forEach((member) => {
+            const li = document.createElement("li");
+            li.textContent = member.name;
+            rosterList.appendChild(li);
+          });
+      }
+
+      function updateProgressStats(progress) {
+        if (!progress || !state.roster) {
+          responseSummary.classList.add("hidden");
+          return;
+        }
+
+        const totalParticipants = state.roster.length;
+        const submitted = Object.values(progress.submissions || {}).filter((entry) => (entry.choices || []).length).length;
+        responseStats.textContent = `${submitted} of ${totalParticipants} participants have responded.`;
+        responseSummary.classList.remove("hidden");
+      }
+
+      function displayJoinFeedback(message, isError = false, isSuccess = false) {
+        if (!message) {
+          joinFeedback.classList.add("hidden");
+          return;
+        }
+        joinFeedback.textContent = message;
+        joinFeedback.classList.remove("hidden", "error", "success");
+        if (isError) joinFeedback.classList.add("error");
+        if (isSuccess) joinFeedback.classList.add("success");
+      }
+
+      function stageLabelFor(stage, mode) {
+        switch (stage) {
+          case "CHOICE":
+            return mode === "multi-tier" ? "Select" : "Respond";
+          case "GROUP":
+            return "Group";
+          case "EXPLANATION":
+            return "Explain";
+          case "SUMMARY":
+            return "Summary";
+          case "ENDED":
+            return "Session Ended";
+          default:
+            return "Lobby";
+        }
+      }
+
+      function modeLabel(mode) {
+        switch (mode) {
+          case "single":
+            return "Single response";
+          case "multi":
+            return "Multi-response";
+          case "multi-tier":
+            return "Multi-tier";
+          default:
+            return "";
+        }
+      }
+
+      function debounce(fn, delay) {
+        let timeout;
+        return (...args) => {
+          clearTimeout(timeout);
+          timeout = setTimeout(() => fn(...args), delay);
+        };
+      }
+
+      function generateId(prefix) {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+          return `${prefix}-${crypto.randomUUID()}`;
+        }
+        return `${prefix}-${Math.random().toString(16).slice(2)}${Date.now()}`;
+      }
     </script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,455 +1,58 @@
-/*******************************************************************
- * server.js
- *
- * Features:
- *  - Teacher automatically creates session on page load (TEACHER_CREATE_SESSION).
- *  - Multiple questions: Start MCQ/Next Question -> Explanation -> ...
- *  - Real-time updates: MCQ answers, typed explanations.
- *  - Stop Quiz ends everything, teacher can download CSV.
- *  - CSV includes columns: Question #, Question Text, Username, MCQ Answer, Explanation.
- *  - Filenames have session code & timestamp (no extra libs required).
- *  - Keeps websockets alive up to 60 min or until quiz stops/closes.
- *******************************************************************/
+const fs = require("fs");
+const path = require("path");
 const express = require("express");
-const http = require("http");
-const crypto = require("crypto");
-const { WebSocketServer } = require("ws");
+
+/**
+ * Lightweight .env loader so we don't rely on external packages.
+ * Only parses simple KEY=VALUE pairs and ignores comments.
+ */
+function loadEnvFile(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    raw.split(/\r?\n/).forEach((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) return;
+      const idx = trimmed.indexOf("=");
+      if (idx === -1) return;
+      const key = trimmed.slice(0, idx).trim();
+      if (!key) return;
+      let value = trimmed.slice(idx + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (process.env[key] === undefined) {
+        process.env[key] = value;
+      }
+    });
+  } catch (err) {
+    // Silently ignore missing or unreadable .env files.
+  }
+}
+
+loadEnvFile(path.join(__dirname, ".env"));
 
 const app = express();
-const server = http.createServer(app);
 
-// Serve the /public folder
-app.use(express.static("public"));
+// Serve static assets from /public
+app.use(express.static(path.join(__dirname, "public")));
 
-// Teacher console at /console
+// Dedicated route for the teacher console
 app.get("/console", (req, res) => {
-  res.sendFile(__dirname + "/public/console.html");
+  res.sendFile(path.join(__dirname, "public", "console.html"));
 });
 
-/**
- * sessions[sessionCode] = {
- *   teacher: WebSocket | null,
- *   stage: 'WAITING' | 'MCQ' | 'EXPLANATION' | 'STOPPED',
- *   currentQuestionIndex: number,
- *   questions: Array<{
- *     questionNumber: number,
- *     questionText: string,
- *     mcqOptions: number,
- *     stage: 'MCQ' | 'EXPLANATION' | 'DONE',
- *     answers: {
- *       [studentId]: {
- *         username: string,
- *         mcqAnswer: number | null,
- *         explanation: string
- *       }
- *     }
- *   }>,
- *   students: {
- *     [studentId]: {
- *       username: string,
- *       ws: WebSocket
- *     }
- *   }
- * }
- */
-const sessions = {};
+// Expose Supabase configuration to the browser safely
+app.get("/env.js", (_req, res) => {
+  const config = {
+    projectUrl: process.env.PROJECT_URL || "",
+    anonKey: process.env.ANON_KEY || "",
+  };
 
-/** Generate a 6-char uppercase hex code (e.g. 'A1B2C3') */
-function generateSessionCode() {
-  return crypto.randomBytes(3).toString("hex").toUpperCase();
-}
-
-/** Safely send JSON via WebSocket */
-function sendJSON(ws, data) {
-  if (ws && ws.readyState === ws.OPEN) {
-    ws.send(JSON.stringify(data));
-  }
-}
-
-/** Broadcast to teacher + all students in a session */
-function broadcastToSession(sessionCode, data) {
-  const session = sessions[sessionCode];
-  if (!session) return;
-  if (session.teacher) sendJSON(session.teacher, data);
-  Object.values(session.students).forEach((stu) => {
-    sendJSON(stu.ws, data);
-  });
-}
-
-/** Gets the current question object (if any) in the session */
-function getCurrentQuestion(sessionCode) {
-  const session = sessions[sessionCode];
-  if (!session) return null;
-  const idx = session.currentQuestionIndex;
-  if (idx < 0 || idx >= session.questions.length) return null;
-  return session.questions[idx];
-}
-
-/**
- * Broadcast a "teacher view" update:
- *  - stage
- *  - current question text, options
- *  - array of answers for that question
- */
-/*******************************************************************
- * server.js
- * (Only relevant parts shown, the rest is unchanged)
- *******************************************************************/
-
-// ... same initial code ...
-
-function broadcastTeacherView(sessionCode) {
-  const session = sessions[sessionCode];
-  if (!session || !session.teacher) return;
-
-  const currentQ = getCurrentQuestion(sessionCode);
-
-  let questionText = "";
-  let mcqOptions = 0;
-  let answersArr = [];
-
-  if (currentQ) {
-    questionText = currentQ.questionText;
-    mcqOptions = currentQ.mcqOptions;
-    // Flatten the answers map into an array for easy UI
-    answersArr = Object.values(currentQ.answers);
-  }
-
-  // NEW: Build a separate array of all student names
-  const studentNames = Object.values(session.students).map((stu) => stu.username);
-
-  sendJSON(session.teacher, {
-    type: "TEACHER_VIEW_UPDATE",
-    payload: {
-      sessionCode,
-      stage: session.stage,
-      questionText,
-      mcqOptions,
-      answers: answersArr,    // for results
-      studentNames: studentNames,  // for real-time "who joined"
-    },
-  });
-}
-
-/** Create CSV with columns: Question#, QuestionText, Username, MCQAnswer, Explanation */
-function generateCSV(session) {
-  const rows = [
-    ["Question #", "Question Text", "Username", "MCQ Answer", "Explanation"]
-  ];
-  session.questions.forEach((q) => {
-    const qNum = q.questionNumber;
-    const qTxt = q.questionText;
-    // For each student's answers
-    for (const studentId in q.answers) {
-      const ans = q.answers[studentId];
-      rows.push([
-        qNum,
-        qTxt,
-        ans.username || "",
-        ans.mcqAnswer || "",
-        ans.explanation || ""
-      ]);
-    }
-  });
-
-  // Convert to CSV string
-  return rows
-    .map((r) => r.map((val) => `"${String(val).replace(/"/g, '""')}"`).join(","))
-    .join("\n");
-}
-
-/** Simple timestamp for filename, e.g. 20230310-150501 */
-function getTimestampString() {
-  const d = new Date();
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  const HH = String(d.getHours()).padStart(2, "0");
-  const MM = String(d.getMinutes()).padStart(2, "0");
-  const SS = String(d.getSeconds()).padStart(2, "0");
-  return `${yyyy}${mm}${dd}-${HH}${MM}${SS}`;
-}
-
-const wss = new WebSocketServer({ server });
-
-wss.on("connection", (ws) => {
-  // Keep track of isAlive for keep-alive pings
-  ws.isAlive = true;
-  ws.on("pong", () => {
-    ws.isAlive = true;
-  });
-
-  ws.on("message", (msg) => {
-    let data;
-    try {
-      data = JSON.parse(msg.toString());
-    } catch (err) {
-      console.log("Invalid JSON from client");
-      return;
-    }
-
-    const { type, payload } = data;
-
-    // ===== TEACHER ACTIONS =====
-    if (type === "TEACHER_CREATE_SESSION") {
-      const code = generateSessionCode();
-      sessions[code] = {
-        teacher: ws,
-        stage: "WAITING",
-        currentQuestionIndex: -1,
-        questions: [],
-        students: {}
-      };
-      console.log("Teacher created session", code);
-
-      sendJSON(ws, {
-        type: "SESSION_CREATED",
-        payload: { sessionCode: code }
-      });
-
-    } else if (type === "TEACHER_START_MCQ") {
-      const { sessionCode, questionText, options } = payload;
-      const session = sessions[sessionCode];
-      if (!session) return;
-
-      session.stage = "MCQ";
-
-      // Mark previous question "DONE" if it was in EXPLANATION
-      if (session.currentQuestionIndex >= 0) {
-        const prevQ = getCurrentQuestion(sessionCode);
-        if (prevQ && prevQ.stage === "EXPLANATION") {
-          prevQ.stage = "DONE";
-        }
-      }
-
-      // Create a new question
-      const newQnum = session.questions.length + 1;
-      const questionObj = {
-        questionNumber: newQnum,
-        questionText: questionText || "",
-        mcqOptions: options,
-        stage: "MCQ",
-        answers: {}
-      };
-      session.questions.push(questionObj);
-      session.currentQuestionIndex = session.questions.length - 1;
-
-      // Add answer slots for existing students
-      Object.entries(session.students).forEach(([stuId, stu]) => {
-        questionObj.answers[stuId] = {
-          username: stu.username,
-          mcqAnswer: null,
-          explanation: ""
-        };
-      });
-
-      broadcastToSession(sessionCode, {
-        type: "MCQ_STARTED",
-        payload: {
-          questionText: questionObj.questionText,
-          options: questionObj.mcqOptions
-        }
-      });
-
-      broadcastTeacherView(sessionCode);
-
-    } else if (type === "TEACHER_NEXT_EXPLANATION") {
-      const { sessionCode } = payload;
-      const session = sessions[sessionCode];
-      if (!session) return;
-
-      session.stage = "EXPLANATION";
-      const curQ = getCurrentQuestion(sessionCode);
-      if (curQ && curQ.stage === "MCQ") {
-        curQ.stage = "EXPLANATION";
-      }
-
-      broadcastToSession(sessionCode, {
-        type: "SHOW_EXPLANATION_INPUT"
-      });
-      broadcastTeacherView(sessionCode);
-
-    } else if (type === "TEACHER_STOP_QUIZ") {
-      const { sessionCode } = payload;
-      const session = sessions[sessionCode];
-      if (!session) return;
-
-      session.stage = "STOPPED";
-      broadcastToSession(sessionCode, {
-        type: "QUIZ_STOPPED"
-      });
-      console.log("Teacher STOP_QUIZ for session", sessionCode);
-
-      // close student websockets
-      Object.values(session.students).forEach((stu) => {
-        stu.ws.close();
-      });
-      broadcastTeacherView(sessionCode);
-
-    } else if (type === "TEACHER_CLOSE_PAGE") {
-      // If teacher closes tab
-      const { sessionCode } = payload;
-      const session = sessions[sessionCode];
-      if (!session) return;
-
-      session.stage = "STOPPED";
-      broadcastToSession(sessionCode, {
-        type: "QUIZ_STOPPED"
-      });
-      console.log("Teacher closed page -> stop session", sessionCode);
-
-      // close all students
-      Object.values(session.students).forEach((stu) => {
-        stu.ws.close();
-      });
-      delete sessions[sessionCode];
-
-    } else if (type === "TEACHER_DOWNLOAD_CSV") {
-      const { sessionCode } = payload;
-      const session = sessions[sessionCode];
-      if (!session) {
-        sendJSON(ws, {
-          type: "ERROR",
-          payload: { message: "No such session." }
-        });
-        return;
-      }
-      const csvStr = generateCSV(session);
-      const ts = getTimestampString();
-      const filename = `quiz_data_${sessionCode}_${ts}.csv`;
-
-      sendJSON(ws, {
-        type: "CSV_DATA",
-        payload: {
-          csv: csvStr,
-          filename
-        }
-      });
-
-    } else if (type === "TEACHER_REJOIN_SESSION") {
-      // If teacher refreshes page
-      const { sessionCode } = payload;
-      if (sessions[sessionCode]) {
-        sessions[sessionCode].teacher = ws;
-        broadcastTeacherView(sessionCode);
-      } else {
-        sendJSON(ws, {
-          type: "ERROR",
-          payload: { message: "Session code not found" }
-        });
-      }
-
-    // ===== STUDENT ACTIONS =====
-    } else if (type === "STUDENT_JOIN_SESSION") {
-      const { sessionCode, username } = payload;
-      const session = sessions[sessionCode];
-      if (!session) {
-        sendJSON(ws, {
-          type: "ERROR",
-          payload: { message: "Invalid session code" }
-        });
-        return;
-      }
-      const studentId = crypto.randomBytes(3).toString("hex");
-      session.students[studentId] = {
-        username,
-        ws
-      };
-
-      console.log(`Student ${username} joined session ${sessionCode}`);
-
-      // If there's a current question, add an answers entry for them
-      const curQ = getCurrentQuestion(sessionCode);
-      if (curQ) {
-        curQ.answers[studentId] = {
-          username,
-          mcqAnswer: null,
-          explanation: ""
-        };
-      }
-
-      sendJSON(ws, {
-        type: "JOINED_SESSION",
-        payload: {
-          studentId,
-          sessionCode,
-          stage: session.stage // WAITING, MCQ, EXPLANATION, STOPPED
-        }
-      });
-
-      broadcastTeacherView(sessionCode);
-
-    } else if (type === "STUDENT_SUBMIT_MCQ") {
-      const { sessionCode, studentId, answer } = payload;
-      const session = sessions[sessionCode];
-      if (!session) return;
-
-      const curQ = getCurrentQuestion(sessionCode);
-      if (!curQ) return;
-
-      if (!curQ.answers[studentId]) {
-        // Student joined late
-        const stuInfo = session.students[studentId];
-        if (!stuInfo) return;
-        curQ.answers[studentId] = {
-          username: stuInfo.username,
-          mcqAnswer: null,
-          explanation: ""
-        };
-      }
-      curQ.answers[studentId].mcqAnswer = answer;
-      broadcastTeacherView(sessionCode);
-
-    } else if (type === "STUDENT_EXPLANATION_UPDATE") {
-      const { sessionCode, studentId, explanation } = payload;
-      const session = sessions[sessionCode];
-      if (!session) return;
-
-      const curQ = getCurrentQuestion(sessionCode);
-      if (!curQ) return;
-
-      if (!curQ.answers[studentId]) {
-        const stuInfo = session.students[studentId];
-        if (!stuInfo) return;
-        curQ.answers[studentId] = {
-          username: stuInfo.username,
-          mcqAnswer: null,
-          explanation: ""
-        };
-      }
-      curQ.answers[studentId].explanation = explanation;
-      broadcastTeacherView(sessionCode);
-    }
-  });
-
-  ws.on("close", () => {
-    // optional cleanup
-  });
+  res.type("application/javascript");
+  res.send(`window.__SUPABASE_CONFIG__ = ${JSON.stringify(config)};`);
 });
 
-// Keep connections alive for up to 60 minutes
-const KEEP_ALIVE_INTERVAL = 30_000; // 30s
-const MAX_DURATION = 60 * 60_000;   // 60 min
-let totalUptime = 0;
-
-const keepAliveInterval = setInterval(() => {
-  totalUptime += KEEP_ALIVE_INTERVAL;
-  if (totalUptime >= MAX_DURATION) {
-    // forcibly close all websockets
-    wss.clients.forEach((ws) => ws.close());
-    clearInterval(keepAliveInterval);
-    return;
-  }
-
-  wss.clients.forEach((ws) => {
-    if (!ws.isAlive) return ws.terminate();
-    ws.isAlive = false;
-    ws.ping();
-  });
-}, KEEP_ALIVE_INTERVAL);
-
-// Start server
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
-  console.log("Server listening on port", PORT);
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- replace the in-app websocket hub with a lightweight Express server that surfaces Supabase credentials via /env.js and loads .env values without external dependencies
- rebuild the facilitator console to drive Supabase realtime channels, support single, multi-response, and multi-tier stages, and present a refreshed professional layout with history and CSV export
- redesign the participant experience with a polished interface that consumes Supabase broadcasts for stage-aware flows including grouping, explanations, and configurable option counts

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68d2a8b2fe7c8327bb03ff59128feba5